### PR TITLE
Updates to Save images into localstorage using Base64 

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
       crossorigin="anonymous"
     ></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"></script>
     <link rel="stylesheet" type="text/css" href="style.css" />
     <link
       rel="stylesheet"

--- a/js/Background.js
+++ b/js/Background.js
@@ -130,11 +130,11 @@ function rmBG_Old() {
   }
 }
 
-function sleep(msec) {
+function sleep(ms) {
   return new Promise(function(resolve) {
     setTimeout(function() {
       resolve();
-    }, msec);
+    }, ms);
   });
 }
 
@@ -165,9 +165,11 @@ function rmLSimgB64() {
       }
     }
   }
-  rmTFskeys.forEach(function(v) {
-    localStorage.removeItem(v);
-  });
+  if (rmTFskeys.length !== 0) {
+    rmTFskeys.forEach(function(v) {
+      localStorage.removeItem(v);
+    });
+  }
 }
 
 async function setBGimgB64() {

--- a/js/Background.js
+++ b/js/Background.js
@@ -6,36 +6,34 @@ function FetchItems() {
   ("use strict");
   var value = "World Heritage";
   function createURL(value) {
-    var API_key = "12743134-37f71928426932ad3d292fa38";
-    var BaseUrl = "https://pixabay.com/api/?key=" + API_key;
-    var keyword = "&q=" + encodeURIComponent(value);
-    var option =
-      "&editorschoice=true&safesearch=true&image_type=photo&orientation=horizontal&per_page=200";
-    var url = BaseUrl + keyword + option;
+    var API_key = "12743134-37f71928426932ad3d292fa38",
+      BaseUrl = "https://pixabay.com/api/?key=" + API_key,
+      keyword = "&q=" + encodeURIComponent(value),
+      option =
+        "&editorschoice=true&safesearch=true&image_type=photo&orientation=horizontal&per_page=200",
+      url = BaseUrl + keyword + option;
     return url;
   }
 
-  var imageURL = createURL(value);
-  var randNum = [];
+  var imageURL = createURL(value),
+    randNum = [];
 
   for (var i = 0; i < 10; i++) {
     randNum[i] = Math.floor(Math.random() * 200);
   }
-  console.log(randNum);
 
   randNum.sort(function(a, b) {
     return a < b ? -1 : 1;
   });
 
-  var urlObject = [];
-  var k = 0;
-
   async function fetchURL() {
-    var res = await fetch(imageURL);
-    var data = await res.json();
+    var res = await fetch(imageURL),
+      data = await res.json();
     return data;
   }
 
+  var urlObject = [],
+    k = 0;
   fetchURL()
     .then(function(data) {
       for (var j = 0; j < randNum.length; j++) {
@@ -50,9 +48,23 @@ function FetchItems() {
   return localStorage.getItem("BG_Rand10Img");
 }
 
+function toDataUrl(url, callback) {
+  var xhr = new XMLHttpRequest();
+  xhr.onload = function() {
+    var reader = new FileReader();
+    reader.onloadend = function() {
+      callback(reader.result);
+    };
+    reader.readAsDataURL(xhr.response);
+  };
+  xhr.open("GET", url);
+  xhr.responseType = "blob";
+  xhr.send();
+}
+
 function createTimeFrame() {
-  var timeframeNum = [];
-  var min = 0,
+  var timeframeNum = [],
+    min = 0,
     max = 9;
   for (i = min; i <= max; i++) {
     while (true) {
@@ -63,18 +75,21 @@ function createTimeFrame() {
       }
     }
   }
-  console.log(timeframeNum);
 
-  var BG_Morning = [];
-  var BG_Daytime = [];
-  var BG_Night = [];
-
-  var imgJson = localStorage.getItem("BG_Rand10Img");
-  var obj = JSON.parse(imgJson);
+  var BG_Morning = [],
+    BG_Daytime = [],
+    BG_Night = [],
+    imgJson = localStorage.getItem("BG_Rand10Img"),
+    obj = JSON.parse(imgJson);
+  for (var v = 0; i < obj.length; i++) {
+    toDataUrl(obj, function(myBase64) {
+      imgBase64.push(myBase64);
+    });
+  }
 
   for (var i = 0; i < 3; i++) {
-    var j = i + 3;
-    var k = i + 6;
+    var j = i + 3,
+      k = i + 6;
     BG_Morning[i] = "url(" + obj[timeframeNum[i]] + ")";
     BG_Daytime[i] = "url(" + obj[timeframeNum[j]] + ")";
     BG_Night[i] = "url(" + obj[timeframeNum[k]] + ")";
@@ -90,14 +105,15 @@ function createTimeFrame() {
 function setTimeFrame() {
   date = new Date();
   today = "BG_" + (date.getMonth() + 1) + "/" + date.getDate();
-  yesterday = date.getMonth() + "/" + date.getDate();
   hour = date.getHours();
+  //set timeframe names(tfs) then set timeframe(tf)
+  tfs = ["Morning", "Daytime", "Night"];
   if (hour >= 4 && hour < 12) {
-    timeframe = "BG_Morning";
+    tf = "BG_" + tfs[0];
   } else if (hour >= 12 && hour < 20) {
-    timeframe = "BG_Daytime";
+    tf = "BG_Daytime";
   } else {
-    timeframe = "BG_Night";
+    tf = "BG_Night";
   }
 }
 
@@ -135,29 +151,35 @@ async function fetchAll() {
   createTimeFrame();
 }
 
-window.onload = async function Background() {
-  setTimeFrame();
-  if (!localStorage.getItem(timeframe)) {
-    rmBG_Old();
-    localStorage.setItem(today, date);
-    fetchAll();
-  } else {
-    if (!localStorage.getItem(today)) {
-      rmBG_Old();
-      localStorage.setItem(today, date);
-      fetchAll();
+//remove Old Base64 img file in Local Storage
+function rmLSimgB64() {
+  var rmTFs = [];
+  tfs.map(function(tf) {
+    rmTFs.push("BG_" + tf + "_imgB64");
+  });
+  var rmTFskeys = [];
+  for (var i = 0; i < localStorage.length; i++) {
+    for (var j = 0; j < rmTFs.length; j++) {
+      if (localStorage.key(i).indexOf(rmTFs[j]) >= 0) {
+        rmTFskeys.push(localStorage.key(i));
+      }
     }
   }
+  rmTFskeys.forEach(function(v) {
+    localStorage.removeItem(v);
+  });
+}
+
+async function setBGimgB64() {
   var count = 0;
-  while (!localStorage.getItem(timeframe)) {
-    await sleep(200);
+  while (!localStorage.getItem(tf)) {
+    await sleep(100);
     if (count > 24) {
       break;
     }
     count++;
   }
-  var bgTime = localStorage.getItem(timeframe);
-  var bgImages = JSON.parse(bgTime);
+  bgImages = JSON.parse(localStorage.getItem(tf));
   var count = 0;
   while (!bgImages) {
     await sleep(200);
@@ -166,6 +188,121 @@ window.onload = async function Background() {
     }
     count++;
   }
-  document.getElementById("bg-img").style.backgroundImage =
-    bgImages[Math.floor(Math.random() * bgImages.length)];
+  //Store img in Base64 data
+  if (!localStorage.getItem(BG_imgB64)) {
+    var imgBase64 = [];
+    for (var i = 0; i < bgImages.length; i++) {
+      bgImages[i] = bgImages[i].slice(4, -1);
+      toDataUrl(bgImages[i], function(myBase64) {
+        imgBase64.push(myBase64);
+      });
+    }
+    while (imgBase64.length !== bgImages.length) {
+      await sleep(200);
+      if (count > 24) {
+        break;
+      }
+      count++;
+    }
+    cmpimgB64 = [];
+    for (var i = 0; i < bgImages.length; i++) {
+      cmpimgB64[i] = LZString.compress(imgBase64[i]);
+    }
+    while (cmpimgB64.length !== imgBase64.length) {
+      await sleep(200);
+      if (count > 24) {
+        break;
+      }
+      count++;
+    }
+    localStorage.setItem(BG_imgB64, JSON.stringify(cmpimgB64));
+  }
+}
+
+async function getBGimgB64() {
+  //getItem and decompress.
+  cmpimgB64 = JSON.parse(localStorage.getItem(BG_imgB64));
+  var count = 0;
+  while (!cmpimgB64) {
+    await sleep(200);
+    if (count > 24) {
+      break;
+    }
+    count++;
+  }
+  //console.log(!!cmpimgB64);
+  B64img = LZString.decompress(
+    cmpimgB64[Math.floor(Math.random() * cmpimgB64.length)]
+  );
+  var count = 0;
+  while (!B64img) {
+    await sleep(200);
+    if (count > 24) {
+      break;
+    }
+    count++;
+  }
+  //console.log(!!B64img);
+}
+
+window.onload = async function Background() {
+  setTimeFrame();
+  BG_imgB64 = tf + "_imgB64";
+  if (
+    localStorage.getItem(tf) !== null &&
+    localStorage.getItem(today) !== null
+  ) {
+    if (localStorage.getItem(BG_imgB64) !== null) {
+      getBGimgB64();
+      var count = 0;
+      while (!localStorage.getItem(BG_imgB64)) {
+        await sleep(200);
+        if (count > 24) {
+          break;
+        }
+        count++;
+      }
+      document.getElementById(
+        "bg-img"
+      ).style.backgroundImage = `url(${B64img})`;
+    } else {
+      var bgImages = JSON.parse(localStorage.getItem(tf));
+      var count = 0;
+      while (!bgImages) {
+        await sleep(200);
+        if (count > 24) {
+          break;
+        }
+        count++;
+      }
+      document.getElementById("bg-img").style.backgroundImage =
+        bgImages[Math.floor(Math.random() * bgImages.length)];
+      rmLSimgB64();
+      setBGimgB64();
+    }
+  } else {
+    rmBG_Old();
+    localStorage.setItem(today, date);
+    fetchAll();
+    var count = 0;
+    while (!localStorage.getItem(tf)) {
+      await sleep(200);
+      if (count > 24) {
+        break;
+      }
+      count++;
+    }
+    var bgImages = JSON.parse(localStorage.getItem(tf));
+    var count = 0;
+    while (!bgImages) {
+      await sleep(200);
+      if (count > 24) {
+        break;
+      }
+      count++;
+    }
+    document.getElementById("bg-img").style.backgroundImage =
+      bgImages[Math.floor(Math.random() * bgImages.length)];
+    setBGimgB64();
+  }
 };


### PR DESCRIPTION
I have set "lz-string" cdn in html to compress image to store in local storage 
 and configured to store Base64 img.
Loading Image URL every time may  affect to load the image. So I updated specification as follows;
previous;
1. Load 10 image URL to store in Local Storage.
2. Divide urls into 3 parts(Morning / Daytime / Night) and store each into Local Storage.
3. set URLs random from same Timeframe(Morning / Daytime / Night).
then if local storage have 10 URLs in each Timeframe, it loads from local storage in same Timeframe
-----
The update
4. Load URL and encode it to Base64  and store it into  Local Storage(1st time).
    and if it is 1st time, we load image from URL (this is to have time to encode / compress image and to store it to Local storage) 
5. If Local Storage does not have  "BG_TimeFrame_imgB64" file, search name and delete it.
    Then set Base 64 files (again it load image from URL instead of loading Base 64).
6.  if Local Storage have  "BG_TimeFrame_imgB64"  file, load it and set to id ="bg-img".

so bg-img has really long src=url( ) when it is base 64.
Please also be noted that you  should not touch "BG_TimeFrame_imgB64" file in Local Storage as it is compressed file. if you open it, you will not be able to check Local storage anymore (take too long to load it even reloading browser).